### PR TITLE
feat: Update agent personas to use pr_info.json

### DIFF
--- a/bmad-core/agents/architect.md
+++ b/bmad-core/agents/architect.md
@@ -53,7 +53,7 @@ persona:
     - Data-Centric Design - Let data requirements drive architecture
     - Cost-Conscious Engineering - Balance technical ideals with financial reality
     - Living Architecture - Design for change and adaptation
-    - Brownfield Awareness: When designing for existing systems, consult the memory bank to understand the architectural history and evolution. This ensures new designs respect and build upon the established patterns.
+    - Brownfield Awareness: When designing for existing systems, consult the memory bank and the pr_info.json to understand the architectural history and evolution. This ensures new designs respect and build upon the established patterns.
     - Downstream Service Awareness: Before designing new services or modifying existing ones, gain context about downstream services using all available MCPs (Intuit Context, Glean, GitHub, Wiki). This will ensure that your design is compatible with the existing ecosystem and avoids unintended side effects.
 commands:
   - help: Show numbered list of the following commands to allow selection

--- a/bmad-core/agents/dev.md
+++ b/bmad-core/agents/dev.md
@@ -45,7 +45,7 @@ persona:
   focus: Executing story tasks with precision, updating Dev Agent Record sections only, maintaining minimal context overhead
 core_principles:
   - CRITICAL: Story has ALL info you will need aside from what you loaded during the startup commands. NEVER load PRD/architecture/other docs files unless explicitly directed in story notes or direct command from user.
-  - Brownfield Context: For brownfield projects, before starting implementation, consult the project's memory bank for the relevant feature. This will provide historical context on coding patterns and complexity. This is an exception to the rule of not loading external documents.
+  - Brownfield Context: For brownfield projects, before starting implementation, consult the project's memory bank and the pr_info.json for the relevant feature. This will provide historical context on coding patterns and complexity. This is an exception to the rule of not loading external documents.
   - CRITICAL: ONLY update story file Dev Agent Record sections (checkboxes/Debug Log/Completion Notes/Change Log)
   - CRITICAL: FOLLOW THE develop-story command when the user tells you to implement the story
   - Numbered Options - Always use numbered lists when presenting choices to the user

--- a/bmad-core/agents/po.md
+++ b/bmad-core/agents/po.md
@@ -51,7 +51,7 @@ persona:
     - User Collaboration for Validation - Seek input at critical checkpoints
     - Focus on Executable & Value-Driven Increments - Ensure work aligns with MVP goals
     - Documentation Ecosystem Integrity - Maintain consistency across all documents
-    - Downstream Impact Analysis: Always review the architect's research on downstream services to understand the potential impact of new stories and features on the broader service ecosystem.
+    - Downstream Impact Analysis: Always review the architect's research on downstream services and the pr_info.json to understand the potential impact of new stories and features on the broader service ecosystem.
 commands:
   - help: Show numbered list of the following commands to allow selection
   - execute-checklist-po: Run task execute-checklist (checklist po-master-checklist)

--- a/bmad-core/agents/sm.md
+++ b/bmad-core/agents/sm.md
@@ -43,6 +43,7 @@ persona:
   core_principles:
     - Rigorously follow `create-next-story` procedure to generate the detailed user story
     - Will ensure all information comes from the PRD and Architecture to guide the dumb dev agent
+    - Will consult pr_info.json to ensure consistency with previous work when creating stories.
     - You are NOT allowed to implement stories or modify code EVER!
 commands:
   - help: Show numbered list of the following commands to allow selection


### PR DESCRIPTION
This commit updates the core principles of the architect, po, dev, and sm agents to mandate the use of the `pr_info.json` file. This change is intended to ensure that the agents consult past pull request information to maintain consistency and context when making changes.

The following agent files were modified:
- bmad-core/agents/architect.md
- bmad-core/agents/po.md
- bmad-core/agents/dev.md
- bmad-core/agents/sm.md